### PR TITLE
methylseq : pass dedup bam to gembs_call

### DIFF
--- a/genpipes/pipelines/methylseq/__init__.py
+++ b/genpipes/pipelines/methylseq/__init__.py
@@ -1241,7 +1241,7 @@ cat {metrics_all_file} | sed 's/%_/perc_/g' | sed 's/#_/num_/g' >> {ihec_multiqc
         jobs = []
         
         for sample in self.samples:
-            bam = os.path.join(self.output_dirs["alignment_directory"], sample.name, sample.name + ".bam")
+            bam = os.path.join(self.output_dirs["alignment_directory"], sample.name, sample.name + ".sorted.dedup.bam")
             output_dir = os.path.join(self.output_dirs["methylation_call_directory"], sample.name)
             output_prefix = os.path.join(output_dir, sample.name)
             config_dir = os.path.join(output_dir, ".gemBS")


### PR DESCRIPTION
gembs does its own duplicate recognition and filtering but for consistency with other protocols, this will now pass the deduplicated bam to gembs_call, instead of the output directly from gembs_map. Gembs_call can use the sam flags from picard_mark_dup. picard_mark_dup step was also already part of the pipeline/protocol, so not a big change to use the dedup bam here.