### PR TITLE
Log report timeouts

### DIFF
--- a/genpipes/core/epilogue.py
+++ b/genpipes/core/epilogue.py
@@ -86,13 +86,12 @@ def parse_slurm_job_info(job_info, job_id):
             job_details['Timelimit'] = row['Timelimit']
             job_details['ReqCPUS'] = row['ReqCPUS']
             job_details['ReqMem'] = row['ReqMem']
+            job_details['State'] = row['State']
 
         # Extracting from the third line (line starting with ${JobID}.0)
         elif row['JobID'] == f"{job_id}.0":
             if 'CANCELLED by ' in row['State']:
                 job_details['State'] = 'OUT_OF_MEMORY'
-            else:
-                job_details['State'] = row['State']
             job_details['Start'] = row['Start']
             job_details['End'] = row['End']
             job_details['Elapsed'] = row['Elapsed']

--- a/genpipes/core/epilogue.py
+++ b/genpipes/core/epilogue.py
@@ -92,7 +92,7 @@ def parse_slurm_job_info(job_info, job_id):
         elif row['JobID'] == f"{job_id}.0":
             if job_details['State'] == 'RUNNING':
                 job_details['State'] = row['State']
-            elif 'CANCELLED by ' in row['State']:
+            if 'CANCELLED by ' in row['State']:
                 job_details['State'] = 'OUT_OF_MEMORY'
             job_details['Start'] = row['Start']
             job_details['End'] = row['End']

--- a/genpipes/core/epilogue.py
+++ b/genpipes/core/epilogue.py
@@ -90,7 +90,9 @@ def parse_slurm_job_info(job_info, job_id):
 
         # Extracting from the third line (line starting with ${JobID}.0)
         elif row['JobID'] == f"{job_id}.0":
-            if 'CANCELLED by ' in row['State']:
+            if job_details['State'] == 'RUNNING':
+                job_details['State'] = row['State']
+            elif 'CANCELLED by ' in row['State']:
                 job_details['State'] = 'OUT_OF_MEMORY'
             job_details['Start'] = row['Start']
             job_details['End'] = row['End']

--- a/genpipes/pipelines/longread_dnaseq/cit.ini
+++ b/genpipes/pipelines/longread_dnaseq/cit.ini
@@ -12,7 +12,7 @@ cluster_walltime = 0:45:0
 threads=6
 sort_threads=4
 cluster_cpu=10
-cluster_mem=4G
+cluster_mem=40G
 cluster_walltime=1:30:00
 
 [nanoplot]

--- a/genpipes/pipelines/longread_dnaseq/cit.ini
+++ b/genpipes/pipelines/longread_dnaseq/cit.ini
@@ -12,8 +12,8 @@ cluster_walltime = 0:45:0
 threads=6
 sort_threads=4
 cluster_cpu=10
-cluster_mem=32G
-cluster_walltime=1:00:00
+cluster_mem=40G
+cluster_walltime=1:30:00
 
 [nanoplot]
 other_options=--loglength --N50 --plots kde

--- a/genpipes/pipelines/longread_dnaseq/cit.ini
+++ b/genpipes/pipelines/longread_dnaseq/cit.ini
@@ -12,7 +12,7 @@ cluster_walltime = 0:45:0
 threads=6
 sort_threads=4
 cluster_cpu=10
-cluster_mem=40G
+cluster_mem=4G
 cluster_walltime=1:30:00
 
 [nanoplot]


### PR DESCRIPTION
<!--
Please make sure your Pull Request is NOT targeting the `main` branch unless it comes from `dev`, `main`, or `release/*`.
Please target `dev` first.
-->

**Base branch**: `dev`

TIMEOUTS were being labeled as CANCELLED in cit runs on beluga. This makes finding the problematic jobs in cit a bit tricky, because there were so many CANCELLED jobs. With `sacct`, the first line will have the state TIMEOUT, while the third line will say CANCELLED. However, for completed jobs, the epilogues were pulling RUNNING from the first line, instead of COMPLETED, so I had to add another `if`. 
