### PR TITLE
Moh linx zip

### DIFF
--- a/pipelines/tumor_pair/tumor_pair.py
+++ b/pipelines/tumor_pair/tumor_pair.py
@@ -7030,7 +7030,7 @@ sed -i s/"isEmail = isLocalSmtp()"/"isEmail = False"/g {input}""".format(
             pair_dir = os.path.join(self.output_dirs['sv_variants_directory'], tumor_pair.name)
             linx_output_dir = os.path.join(pair_dir, "linx")
             linx_plot_dir = os.path.join(linx_output_dir, "plot")
-            linx_zip = os.path.join(linx_output_dir, tumor_pair.name + ".linx_plot.zip")
+            linx_zip = os.path.join(linx_output_dir, f"{tumor_pair.name}.linx_plot.zip")
 
             jobs.append(
                 concat_jobs(
@@ -7058,7 +7058,7 @@ sed -i s/"isEmail = isLocalSmtp()"/"isEmail = False"/g {input}""".format(
                 )
             )
         return jobs
-    
+
     def report_djerba(self):
         """
         Produce Djerba report.
@@ -7069,19 +7069,19 @@ sed -i s/"isEmail = isLocalSmtp()"/"isEmail = False"/g {input}""".format(
             "ensemble"
             )
         assembly = config.param('report_pcgr', 'assembly')
-        
+
         for tumor_pair in self.tumor_pairs.values():
             djerba_dir = os.path.join(self.output_dirs['report'][tumor_pair.name], "djerba")
             purple_dir = os.path.join(self.output_dirs['paired_variants_directory'], tumor_pair.name, "purple") # has to be a zipped directory, create zip file as part of job
             purple_zip = os.path.join(djerba_dir, tumor_pair.tumor.name + ".purple.zip")
-            
+
             cpsr_directory = os.path.join(ensemble_directory, tumor_pair.name, "cpsr")
             input_cpsr = os.path.join(cpsr_directory, tumor_pair.name + ".cpsr." + assembly + ".json.gz")
             input_vcf = os.path.join(ensemble_directory, tumor_pair.name, tumor_pair.name + ".ensemble.somatic.vt.annot.2caller.flt.vcf.gz")
             pcgr_directory = os.path.join(djerba_dir, "pcgr")
             input_maf = os.path.join(pcgr_directory, tumor_pair.name + ".pcgr_acmg." + assembly + ".maf")
             clean_maf =  os.path.join(pcgr_directory, tumor_pair.name + ".pcgr_acmg." + assembly + ".clean.maf") # MAF from pcgr version 1.4.1 required, remove any empty t_depth lines, needs to be gzipped
-            
+
             provenance_decoy = os.path.join(djerba_dir, "provenance_subset.tsv.gz")
             config_file = os.path.join(djerba_dir, tumor_pair.name + ".djerba.ini")
             djerba_script = os.path.join(djerba_dir, "djerba_report." + tumor_pair.name + ".sh")

--- a/pipelines/tumor_pair/tumor_pair.py
+++ b/pipelines/tumor_pair/tumor_pair.py
@@ -7029,6 +7029,9 @@ sed -i s/"isEmail = isLocalSmtp()"/"isEmail = False"/g {input}""".format(
         for tumor_pair in self.tumor_pairs.values():
             pair_dir = os.path.join(self.output_dirs['sv_variants_directory'], tumor_pair.name)
             linx_output_dir = os.path.join(pair_dir, "linx")
+            linx_plot_dir = os.path.join(linx_output_dir, "plot")
+            linx_zip = os.path.join(linx_output_dir, tumor_pair.name + ".linx_plot.zip")
+
             jobs.append(
                 concat_jobs(
                     [
@@ -7038,12 +7041,20 @@ sed -i s/"isEmail = isLocalSmtp()"/"isEmail = False"/g {input}""".format(
                             linx_output_dir,
                             ini_section="linx_plot"
                         ),
-                        bash.touch(os.path.join(linx_output_dir, "linx_plot." + tumor_pair.name + ".Done"))
+                        bash.touch(os.path.join(linx_output_dir, "linx_plot." + tumor_pair.name + ".Done")),
+                        bash.zip(
+                            linx_plot_dir,
+                            linx_zip,
+                            recursive=True
+                        )
                     ],
                     name="linx_plot." + tumor_pair.name,
                     samples=[tumor_pair.tumor],
                     readsets=list(tumor_pair.tumor.readsets),
-                    output_dependency=[os.path.join(linx_output_dir, "linx_plot." + tumor_pair.name + ".Done")]
+                    output_dependency=[
+                        os.path.join(linx_output_dir, "linx_plot." + tumor_pair.name + ".Done"),
+                        linx_zip
+                        ]
                 )
             )
         return jobs

--- a/pipelines/tumor_pair/tumor_pair.py
+++ b/pipelines/tumor_pair/tumor_pair.py
@@ -7041,7 +7041,7 @@ sed -i s/"isEmail = isLocalSmtp()"/"isEmail = False"/g {input}""".format(
                             linx_output_dir,
                             ini_section="linx_plot"
                         ),
-                        bash.touch(os.path.join(linx_output_dir, "linx_plot." + tumor_pair.name + ".Done")),
+                        bash.touch(os.path.join(linx_output_dir, "plot", "linx_plot." + tumor_pair.name + ".Done")),
                         bash.zip(
                             linx_plot_dir,
                             linx_zip,
@@ -7052,7 +7052,7 @@ sed -i s/"isEmail = isLocalSmtp()"/"isEmail = False"/g {input}""".format(
                     samples=[tumor_pair.tumor],
                     readsets=list(tumor_pair.tumor.readsets),
                     output_dependency=[
-                        os.path.join(linx_output_dir, "linx_plot." + tumor_pair.name + ".Done"),
+                        os.path.join(linx_output_dir, "plot", "linx_plot." + tumor_pair.name + ".Done"),
                         linx_zip
                         ]
                 )

--- a/pipelines/tumor_pair/tumor_pair.py
+++ b/pipelines/tumor_pair/tumor_pair.py
@@ -7041,7 +7041,7 @@ sed -i s/"isEmail = isLocalSmtp()"/"isEmail = False"/g {input}""".format(
                             linx_output_dir,
                             ini_section="linx_plot"
                         ),
-                        bash.touch(os.path.join(linx_output_dir, "plot", "linx_plot." + tumor_pair.name + ".Done")),
+                        bash.touch(os.path.join(linx_plot_dir, f"linx_plot.{tumor_pair.name}.Done")),
                         bash.zip(
                             linx_plot_dir,
                             linx_zip,
@@ -7052,7 +7052,7 @@ sed -i s/"isEmail = isLocalSmtp()"/"isEmail = False"/g {input}""".format(
                     samples=[tumor_pair.tumor],
                     readsets=list(tumor_pair.tumor.readsets),
                     output_dependency=[
-                        os.path.join(linx_output_dir, "plot", "linx_plot." + tumor_pair.name + ".Done"),
+                        os.path.join(linx_plot_dir, f"linx_plot.{tumor_pair.name}.Done"),
                         linx_zip
                         ]
                 )


### PR DESCRIPTION
Adding zipping for linx_plot directory to make delivery easier. Linx plot creates a variable number of output plots that have unpredictable names. 

Waiting for test on beluga to run.