### PR TITLE
ampliconseq : fix typo to search for char variable, not string

### DIFF
--- a/genpipes/pipelines/ampliconseq/__init__.py
+++ b/genpipes/pipelines/ampliconseq/__init__.py
@@ -141,7 +141,7 @@ Parameters:
                     #check the highest position of any ambiguous nucleotide
                     for item in prim_adap_list:
                         for char in ambi_char:
-                            check_ambi_pos = item.rfind(f'char')
+                            check_ambi_pos = item.rfind(f'{char}')
                             headcrop_value = max(headcrop_value, check_ambi_pos + 1)
 
             if readset.run_type == "PAIRED_END":


### PR DESCRIPTION
Fixing a small error that Danielle discovered. Was likely introduced to ampliconseq when adding docstrings to the pipeline. 
