### PR TITLE
flip check for existing bam index to allow starts from step 1

### DIFF
--- a/pipelines/common.py
+++ b/pipelines/common.py
@@ -499,9 +499,9 @@ pandoc \\
                 # If this sample has one readset only, create a sample BAM symlink to the readset BAM, along with its index.
                 if len(sample.readsets) == 1:
                     readset_bam = readset_bams[0]
-                    readset_index = re.sub("\.bam$", ".bam.bai", readset_bam)
+                    readset_index = re.sub("\.bam$", ".bai", readset_bam)
                     if not os.path.exists(readset_index):
-                        readset_index = re.sub("\.bam$", ".bai", readset_bam)
+                        readset_index = re.sub("\.bam$", ".bam.bai", readset_bam)
                     sample_index = re.sub("\.bam$", ".bam.bai", sample_bam)
 
                     if alignment_directory in readset_bam:


### PR DESCRIPTION
Small fix for MOH branch. Gerardo reported this issue because he was running moh samples from step 1, instead of step 5. The pipeline was wrongly looking for the `.bai` index. 

Flipping the order of the indexes that is looked for fixes this. 