### PR TITLE
Log report fix

### DIFF
--- a/genpipes/core/epilogue.py
+++ b/genpipes/core/epilogue.py
@@ -233,7 +233,7 @@ def time_str_to_seconds(time_str):
         h, m, s = parts
         if '-' in h:
             d, h = h.split('-')
-            h = d * 24 + h
+            h = (int(d) * 24) + int(h)
     elif len(parts) == 2:
         h = '0'
         m, s = parts

--- a/genpipes/tools/log_report.py
+++ b/genpipes/tools/log_report.py
@@ -194,7 +194,7 @@ def get_report(job_list_tsv=None):
 
 def parse_time(time_str):
     """
-    Parse a time string in the format HH:MM:SS or MM:SS or SS
+    Parse a time string in the format D-HH:MM:SS or HH:MM:SS or MM:SS or SS
     Args:
         time_str: time string
     Returns:
@@ -205,6 +205,9 @@ def parse_time(time_str):
     parts = time_str.split(':')
     if len(parts) == 3:
         h, m, s = parts
+        if '-' in h:
+            d, h = h.split('-')
+            h = d * 24 + h
     elif len(parts) == 2:
         h = '0'
         m, s = parts

--- a/genpipes/tools/log_report.py
+++ b/genpipes/tools/log_report.py
@@ -207,7 +207,7 @@ def parse_time(time_str):
         h, m, s = parts
         if '-' in h:
             d, h = h.split('-')
-            h = d * 24 + h
+            h = (int(d) * 24) + int(h)
             print(h)
     elif len(parts) == 2:
         h = '0'

--- a/genpipes/tools/log_report.py
+++ b/genpipes/tools/log_report.py
@@ -208,7 +208,6 @@ def parse_time(time_str):
         if '-' in h:
             d, h = h.split('-')
             h = (int(d) * 24) + int(h)
-            print(h)
     elif len(parts) == 2:
         h = '0'
         m, s = parts

--- a/genpipes/tools/log_report.py
+++ b/genpipes/tools/log_report.py
@@ -208,6 +208,7 @@ def parse_time(time_str):
         if '-' in h:
             d, h = h.split('-')
             h = d * 24 + h
+            print(h)
     elif len(parts) == 2:
         h = '0'
         m, s = parts


### PR DESCRIPTION
Reported by Gerardo - Total CPU time is reported as D-HH:MM:SS on rorqual, instead of HH:MM:SS, so this caused an error with the log report for very long jobs:

ValueError: invalid literal for int() with base 10: '5-21'

Fixed here. Also made a small update to epilogue to ensure that the hour is passed as an integer, not a string. 