### PR TITLE
Pcgr project tracking

### DIFF
--- a/genpipes/core/epilogue.py
+++ b/genpipes/core/epilogue.py
@@ -1,4 +1,4 @@
-#!/cvmfs/soft.mugqic/CentOS6/software/python/Python-3.12.2/bin/python
+#!/usr/bin/env python
 
 import csv
 import os

--- a/genpipes/core/prologue.py
+++ b/genpipes/core/prologue.py
@@ -1,4 +1,4 @@
-#!/cvmfs/soft.mugqic/CentOS6/software/python/Python-3.12.2/bin/python
+#!/usr/bin/env python
 
 import csv
 import os

--- a/genpipes/core/scheduler.py
+++ b/genpipes/core/scheduler.py
@@ -333,7 +333,8 @@ mkdir -p $JOB_OUTPUT_DIR/$STEP
   -j \\"{job_name}\\" \\{metrics}
   -o \\"{json_outfile}\\" \\
   -f {status}
-export PT_JSON_OUTFILE=\\"{json_outfile}\\" {command_separator}
+export PT_JSON_OUTFILE=\\"{json_outfile}\\"
+export TIMESTAMP=\\"{timestamp}\\" {command_separator}
 """.format(
             job2json_project_tracking_script="genpipes tools job2json_project_tracking",
             samples=",".join([sample.name for sample in job.samples]),
@@ -341,6 +342,7 @@ export PT_JSON_OUTFILE=\\"{json_outfile}\\" {command_separator}
             job_name=job.name,
             metrics=('\n  -m \\"' + ','.join(job.metrics) + '\\" \\') if job.metrics else '',
             json_outfile=json_outfile,
+            timestamp=pipeline.timestamp,
             status=job_status,
             command_separator="&&" if (job_status=='\\"RUNNING\\"') else ""
         ) if json_outfile else ""

--- a/genpipes/core/scheduler.py
+++ b/genpipes/core/scheduler.py
@@ -334,7 +334,7 @@ mkdir -p $JOB_OUTPUT_DIR/$STEP
   -o \\"{json_outfile}\\" \\
   -f {status}
 export PT_JSON_OUTFILE=\\"{json_outfile}\\"
-export TIMESTAMP=\\"{timestamp}\\" {command_separator}
+export TIME_STAMP=\\"{timestamp}\\" {command_separator}
 """.format(
             job2json_project_tracking_script="genpipes tools job2json_project_tracking",
             samples=",".join([sample.name for sample in job.samples]),

--- a/genpipes/core/scheduler.py
+++ b/genpipes/core/scheduler.py
@@ -334,7 +334,7 @@ mkdir -p $JOB_OUTPUT_DIR/$STEP
   -o \\"{json_outfile}\\" \\
   -f {status}
 export PT_JSON_OUTFILE=\\"{json_outfile}\\"
-export TIME_STAMP=\\"{timestamp}\\" {command_separator}
+export TIMESTAMP=\\"{timestamp}\\" {command_separator}
 """.format(
             job2json_project_tracking_script="genpipes tools job2json_project_tracking",
             samples=",".join([sample.name for sample in job.samples]),

--- a/genpipes/pipelines/dnaseq/__init__.py
+++ b/genpipes/pipelines/dnaseq/__init__.py
@@ -2822,7 +2822,7 @@ END
 
                 if self.project_tracking_json:
                     samples = [sample]
-                    pcgr_output_file = os.path.join(self.output_dir, "job_output", "report_pcgr", f"{job_name}_$TIME_STAMP.o")
+                    pcgr_output_file = os.path.join(self.output_dir, "job_output", "report_pcgr", f"{job_name}_\$TIME_STAMP.o")
                     jobs.append(
                         concat_jobs(
                             [

--- a/genpipes/pipelines/dnaseq/__init__.py
+++ b/genpipes/pipelines/dnaseq/__init__.py
@@ -2822,7 +2822,7 @@ END
 
                 if self.project_tracking_json:
                     samples = [sample]
-                    pcgr_output_file = os.path.join(self.output_dir, "job_output", "report_pcgr", f"{job_name}_$TIME_STAMP.o")
+                    pcgr_output_file = os.path.join(self.output_dir, "job_output", "report_pcgr", f"{job_name}_$TIMESTAMP.o")
                     jobs.append(
                         concat_jobs(
                             [
@@ -2960,7 +2960,7 @@ END
                 samples = [tumor_pair.normal, tumor_pair.tumor]
 
                 if self.project_tracking_json:
-                    pcgr_output_file = os.path.join(self.output_dir, "job_output", "report_pcgr", f"{job_name}_$TIME_STAMP.o")
+                    pcgr_output_file = os.path.join(self.output_dir, "job_output", "report_pcgr", f"{job_name}_$TIMESTAMP.o")
                     jobs.append(
                         concat_jobs(
                             [

--- a/genpipes/pipelines/dnaseq/__init__.py
+++ b/genpipes/pipelines/dnaseq/__init__.py
@@ -2822,7 +2822,7 @@ END
 
                 if self.project_tracking_json:
                     samples = [sample]
-                    pcgr_output_file = os.path.join(self.output_dir, "job_output", "report_pcgr", f"{job_name}_{self.timestamp}.o")
+                    pcgr_output_file = os.path.join(self.output_dir, "job_output", "report_pcgr", f"{job_name}_$TIMESTAMP.o")
                     jobs.append(
                         concat_jobs(
                             [

--- a/genpipes/pipelines/dnaseq/__init__.py
+++ b/genpipes/pipelines/dnaseq/__init__.py
@@ -2822,7 +2822,7 @@ END
 
                 if self.project_tracking_json:
                     samples = [sample]
-                    pcgr_output_file = os.path.join(self.output_dir, "job_output", "report_pcgr", f"{job_name}_\$TIME_STAMP.o")
+                    pcgr_output_file = os.path.join(self.output_dir, "job_output", "report_pcgr", f"{job_name}_$TIME_STAMP.o")
                     jobs.append(
                         concat_jobs(
                             [
@@ -2960,7 +2960,7 @@ END
                 samples = [tumor_pair.normal, tumor_pair.tumor]
 
                 if self.project_tracking_json:
-                    pcgr_output_file = os.path.join(self.output_dir, "job_output", "report_pcgr", f"{job_name}_{self.timestamp}.o")
+                    pcgr_output_file = os.path.join(self.output_dir, "job_output", "report_pcgr", f"{job_name}_$TIME_STAMP.o")
                     jobs.append(
                         concat_jobs(
                             [

--- a/genpipes/pipelines/dnaseq/__init__.py
+++ b/genpipes/pipelines/dnaseq/__init__.py
@@ -3958,7 +3958,7 @@ cp {snv_metrics_prefix}.chromosomeChange.zip report/SNV.chromosomeChange.zip""",
                         name=f"cnvkit_batch.cna.{sample_name}",
                         samples=samples,
                         readsets=readsets,
-                        input_dependency=[input_cna, output_cna],
+                        input_dependency=[input_cna],
                         output_dependency=[header, output_cna_body, output_cna]
                     )
                 )
@@ -4197,7 +4197,7 @@ cp {snv_metrics_prefix}.chromosomeChange.zip report/SNV.chromosomeChange.zip""",
                         name=f"cnvkit_batch.cna.{sample_name}",
                         samples=[tumor_pair.normal, tumor_pair.tumor],
                         readsets=[*list(tumor_pair.normal.readsets), *list(tumor_pair.tumor.readsets)],
-                        input_dependency=[input_cna, output_cna],
+                        input_dependency=[input_cna],
                         output_dependency=[header, output_cna_body, output_cna],
                         removable_files=[header, output_cna_body]
                     )

--- a/genpipes/pipelines/dnaseq/__init__.py
+++ b/genpipes/pipelines/dnaseq/__init__.py
@@ -2822,7 +2822,7 @@ END
 
                 if self.project_tracking_json:
                     samples = [sample]
-                    pcgr_output_file = os.path.join(self.output_dir, "job_output", "report_pcgr", f"{job_name}_$TIMESTAMP.o")
+                    pcgr_output_file = os.path.join(self.output_dir, "job_output", "report_pcgr", f"{job_name}_$TIME_STAMP.o")
                     jobs.append(
                         concat_jobs(
                             [

--- a/genpipes/pipelines/longread_dnaseq/__init__.py
+++ b/genpipes/pipelines/longread_dnaseq/__init__.py
@@ -1911,7 +1911,7 @@ For information on the structure and contents of the LongRead readset file, plea
 
                 if self.project_tracking_json:
                     samples = [sample]
-                    pcgr_output_file = os.path.join(self.output_dir, "job_output", "report_pcgr", f"{job_name}_$TIME_STAMP.o")
+                    pcgr_output_file = os.path.join(self.output_dir, "job_output", "report_pcgr", f"{job_name}_$TIMESTAMP.o")
                     jobs.append(
                         concat_jobs(
                             [
@@ -2024,7 +2024,7 @@ For information on the structure and contents of the LongRead readset file, plea
                 samples = [tumor_pair.normal, tumor_pair.tumor]
 
                 if self.project_tracking_json:
-                    pcgr_output_file = os.path.join(self.output_dir, "job_output", "report_pcgr", f"{job_name}_$TIME_STAMP.o")
+                    pcgr_output_file = os.path.join(self.output_dir, "job_output", "report_pcgr", f"{job_name}_$TIMESTAMP.o")
                     jobs.append(
                         concat_jobs(
                             [

--- a/genpipes/pipelines/longread_dnaseq/__init__.py
+++ b/genpipes/pipelines/longread_dnaseq/__init__.py
@@ -1911,7 +1911,7 @@ For information on the structure and contents of the LongRead readset file, plea
 
                 if self.project_tracking_json:
                     samples = [sample]
-                    pcgr_output_file = os.path.join(self.output_dir, "job_output", "report_pcgr", f"{job_name}_{self.timestamp}.o")
+                    pcgr_output_file = os.path.join(self.output_dir, "job_output", "report_pcgr", f"{job_name}_$TIME_STAMP.o")
                     jobs.append(
                         concat_jobs(
                             [
@@ -2024,7 +2024,7 @@ For information on the structure and contents of the LongRead readset file, plea
                 samples = [tumor_pair.normal, tumor_pair.tumor]
 
                 if self.project_tracking_json:
-                    pcgr_output_file = os.path.join(self.output_dir, "job_output", "report_pcgr", f"{job_name}_{self.timestamp}.o")
+                    pcgr_output_file = os.path.join(self.output_dir, "job_output", "report_pcgr", f"{job_name}_$TIME_STAMP.o")
                     jobs.append(
                         concat_jobs(
                             [

--- a/genpipes/pipelines/rnaseq_light/__init__.py
+++ b/genpipes/pipelines/rnaseq_light/__init__.py
@@ -77,7 +77,7 @@ It is especially useful for quick Quality Control (QC) in gene sequencing studie
         transcriptome_file = global_conf.global_get('kallisto', 'transcriptome_idx', param_type="filepath")
         tx2genes_file = global_conf.global_get('kallisto', 'transcript2genes', param_type="filepath")
         bootstraps = global_conf.global_get('kallisto', 'bootstraps')
-        other_param = global_conf.global_get('kallisto', 'other_options', required=False)
+        other_param = global_conf.global_get('kallisto', 'other_parameters', required=False)
 
         jobs = []
 


### PR DESCRIPTION
Addresses:

- fix for restarts of report_pcgr because of timestamp in one of the input files. Makes use of env variable to keep `.sh` files identical between restarts
- fix for Kallisto adding `other_options` from config file twice (introduced a few weeks ago)
- removed job outputs from the input dependencies listed for cnvkit_batch.cna. Was causing restarts because output file modifications were recognized as being younger than input file modification times.
- shebang line for epilogue.py and prologue.py changed to avoid python version conflicts