### PR TITLE
Md5sum calculation for project tracking (--json-pt)

### DIFF
--- a/genpipes/bfx/job2json_project_tracking.py
+++ b/genpipes/bfx/job2json_project_tracking.py
@@ -25,7 +25,7 @@ from ..core.job import Job
 
 log = logging.getLogger(__name__)
 
-def run(input_file, samples, readsets, job_name, metrics, output_files):
+def run(input_file, samples, readsets, job_name, metrics):
     """
     Calls job2json_project_tracking within jobs to update metrics
     """

--- a/genpipes/bfx/job2json_project_tracking.py
+++ b/genpipes/bfx/job2json_project_tracking.py
@@ -43,7 +43,8 @@ module purge && \\
   -r {readsets} \\
   -j {job_name} \\
   -o $PT_JSON_OUTFILE \\
-  -m {metrics}""".format(
+  -m {metrics} \\
+  -F ${JOB_OUTPUT_FILES:-}""".format(
     job2json_project_tracking_script=os.path.join(os.path.dirname(os.path.dirname(os.path.realpath(__file__))), "tools", "job2json_project_tracking.py"),
     samples=samples,
     readsets=readsets,

--- a/genpipes/bfx/job2json_project_tracking.py
+++ b/genpipes/bfx/job2json_project_tracking.py
@@ -25,7 +25,7 @@ from ..core.job import Job
 
 log = logging.getLogger(__name__)
 
-def run(input_file, samples, readsets, job_name, metrics):
+def run(input_file, samples, readsets, job_name, metrics, output_files):
     """
     Calls job2json_project_tracking within jobs to update metrics
     """
@@ -38,18 +38,16 @@ def run(input_file, samples, readsets, job_name, metrics):
         [],
         command="""\
 module purge && \\
-: "${JOB_OUTPUT_FILES:={placeholder}}" && \\
 {job2json_project_tracking_script} \\
   -s {samples} \\
   -r {readsets} \\
   -j {job_name} \\
   -o $PT_JSON_OUTFILE \\
-  -m {metrics} \\
-  -F ${JOB_OUTPUT_FILES:-}""".format(
+  -m {metrics}""".format(
     job2json_project_tracking_script=os.path.join(os.path.dirname(os.path.dirname(os.path.realpath(__file__))), "tools", "job2json_project_tracking.py"),
     samples=samples,
     readsets=readsets,
     job_name=job_name,
-    metrics=metrics
+    metrics=metrics,
     )
   )

--- a/genpipes/bfx/job2json_project_tracking.py
+++ b/genpipes/bfx/job2json_project_tracking.py
@@ -38,6 +38,7 @@ def run(input_file, samples, readsets, job_name, metrics):
         [],
         command="""\
 module purge && \\
+: "${JOB_OUTPUT_FILES:={placeholder}}" && \\
 {job2json_project_tracking_script} \\
   -s {samples} \\
   -r {readsets} \\

--- a/genpipes/bfx/jsonator_project_tracking.py
+++ b/genpipes/bfx/jsonator_project_tracking.py
@@ -94,7 +94,8 @@ def create(pipeline, sample):
                             if extension:
                                 file_json = {
                                     'location_uri': f'{path_prefix}/{output_file}',
-                                    'file_name': os.path.basename(output_file)
+                                    'file_name': os.path.basename(output_file),
+                                    'file_md5sum': None
                                     }
                                 job_json['file'].append(file_json)
                         else:

--- a/genpipes/tools/job2json_project_tracking.py
+++ b/genpipes/tools/job2json_project_tracking.py
@@ -13,8 +13,13 @@ import random
 import shutil
 import signal
 import hashlib
+import logging 
 
 from datetime import datetime
+
+logging.basicConfig(level=logging.INFO)
+log = logging.getLogger(__name__)
+
 
 def main(args=None):
     """
@@ -82,27 +87,28 @@ def main(args=None):
                                             'metric_value': metric_value
                                             }]
                                 if args.file_paths:
-                                    file_paths = [p for p in args.file_paths.split(",") if p.strip()]
+                                    file_paths = [p.strip() for p in args.file_paths.split(",") if p.strip()]
                                     for fp in file_paths:
                                         base = os.path.basename(fp)
                                         md5 = compute_md5sum(fp) if os.path.exists(fp) and os.path.isfile(fp) else None
-                                        try:
-                                            for fobj in job['file']:
-                                                if fobj.get('file_name') == base:
-                                                    fobj['file_md5sum'] = md5
-                                                    break
-                                            else:
-                                                job['file'].append({
-                                                    'location_uri': None,
-                                                    'file_name': base,
-                                                    'file_md5sum': md5
-                                                })
-                                        except KeyError:
-                                            job['file'] = [{
+
+                                        found = False
+                                        for fobj in job.get('file', []):
+                                            if fobj.get('file_name') == base:
+                                                fobj['file_md5sum'] = md5
+                                                found = True
+                                                break
+
+                                        if not found:
+                                            if 'file' not in job:
+                                                job['file'] = []
+                                            job['file'].append({
                                                 'location_uri': None,
                                                 'file_name': base,
                                                 'file_md5sum': md5
-                                            }]
+                                            })
+
+                                
 
 
         # Print to file
@@ -150,6 +156,7 @@ def compute_md5sum(filepath, block_size=8 * 1024 * 1024):
                 h.update(chunk)
             return h.hexdigest()
     except Exception as exc:
+        log.debug ("compute_md5sum: could not read '%s': %s", filepath, exc)
         return None
 
 

--- a/genpipes/tools/job2json_project_tracking.py
+++ b/genpipes/tools/job2json_project_tracking.py
@@ -145,15 +145,15 @@ def compute_md5sum(filepath, block_size=8 * 1024 * 1024):
         return None
     
 def uri_to_local_path(uri):
+    """
+    Convert location_uri to local path (removing name of cluster)
+    """
     if uri is None:
         return None
     parts = uri.split("://", 1)
     if len(parts) == 2:
         return parts[1]   
-
     return uri
-
-
 
 if __name__ == '__main__':
     main()

--- a/genpipes/tools/job2json_project_tracking.py
+++ b/genpipes/tools/job2json_project_tracking.py
@@ -13,8 +13,11 @@ import random
 import shutil
 import signal
 import hashlib
+import logging
 
 from datetime import datetime
+
+log = logging.getLogger(__name__)
 
 def main(args=None):
     """
@@ -136,6 +139,7 @@ def compute_md5sum(filepath, block_size=8 * 1024 * 1024):
                 h.update(chunk)
             return h.hexdigest()
     except Exception as exc:
+        log.debug ("compute_md5sum: could not read '%s': %s", filepath, exc)
         return None
     
 def uri_to_local_path(uri):

--- a/genpipes/tools/job2json_project_tracking.py
+++ b/genpipes/tools/job2json_project_tracking.py
@@ -87,16 +87,12 @@ def main(args=None):
                                             }]
                                 for fobj in job.get('file', []):
                                     uri = fobj.get("location_uri")
-                                    print("URI:", uri)
                                     local_path = uri_to_local_path(uri)
-                                    print("Local path:", local_path)
 
                                     if local_path and os.path.exists(local_path) and os.path.isfile(local_path):
                                         md5 = compute_md5sum(local_path)
-                                        print("md5sum computed", md5)
                                     else:
                                         md5 = None
-                                        print("error")
 
                                     fobj["file_md5sum"] = md5
                         

--- a/genpipes/tools/job2json_project_tracking.py
+++ b/genpipes/tools/job2json_project_tracking.py
@@ -13,13 +13,8 @@ import random
 import shutil
 import signal
 import hashlib
-import logging 
 
 from datetime import datetime
-
-logging.basicConfig(level=logging.INFO)
-log = logging.getLogger(__name__)
-
 
 def main(args=None):
     """
@@ -141,7 +136,6 @@ def compute_md5sum(filepath, block_size=8 * 1024 * 1024):
                 h.update(chunk)
             return h.hexdigest()
     except Exception as exc:
-        log.debug ("compute_md5sum: could not read '%s': %s", filepath, exc)
         return None
     
 def uri_to_local_path(uri):

--- a/genpipes/tools/job2json_project_tracking.py
+++ b/genpipes/tools/job2json_project_tracking.py
@@ -87,12 +87,16 @@ def main(args=None):
                                             }]
                                 for fobj in job.get('file', []):
                                     uri = fobj.get("location_uri")
+                                    print("URI:", uri)
                                     local_path = uri_to_local_path(uri)
+                                    print("Local path:", local_path)
 
                                     if local_path and os.path.exists(local_path) and os.path.isfile(local_path):
                                         md5 = compute_md5sum(local_path)
+                                        print("md5sum computed", md5)
                                     else:
                                         md5 = None
+                                        print("error")
 
                                     fobj["file_md5sum"] = md5
                         

--- a/genpipes/tools/job2json_project_tracking.py
+++ b/genpipes/tools/job2json_project_tracking.py
@@ -33,7 +33,6 @@ def main(args=None):
         parser.add_argument('-m', '--metrics', required=False, help="comma-separated list of metrics of the current job: name=value,name=value,... With <name> = metric name; <value> = metric value")
         parser.add_argument('-o','--json_outfile', required=True, help="name of json output file")
         parser.add_argument('-f', '--status', required=False, help="status of job")
-        parser.add_argument('-F', '--file_paths', required=False, help="comma-separated list of output file paths to compute MD5 for (paths as on the executing node)")
         args = parser.parse_args()
 
     sample_list = args.sample_names.split(",")
@@ -86,31 +85,17 @@ def main(args=None):
                                             'metric_name': metric_name,
                                             'metric_value': metric_value
                                             }]
-                                if args.file_paths:
-                                    file_paths = [p.strip() for p in args.file_paths.split(",") if p.strip()]
-                                    for fp in file_paths:
-                                        base = os.path.basename(fp)
-                                        md5 = compute_md5sum(fp) if os.path.exists(fp) and os.path.isfile(fp) else None
+                                for fobj in job.get('file', []):
+                                    uri = fobj.get("location_uri")
+                                    local_path = uri_to_local_path(uri)
 
-                                        found = False
-                                        for fobj in job.get('file', []):
-                                            if fobj.get('file_name') == base:
-                                                fobj['file_md5sum'] = md5
-                                                found = True
-                                                break
+                                    if local_path and os.path.exists(local_path) and os.path.isfile(local_path):
+                                        md5 = compute_md5sum(local_path)
+                                    else:
+                                        md5 = None
 
-                                        if not found:
-                                            if 'file' not in job:
-                                                job['file'] = []
-                                            job['file'].append({
-                                                'location_uri': None,
-                                                'file_name': base,
-                                                'file_md5sum': md5
-                                            })
-
-                                
-
-
+                                    fobj["file_md5sum"] = md5
+                        
         # Print to file
         with open(args.json_outfile, 'w') as out_json:
             json.dump(current_json, out_json, indent=4)
@@ -158,6 +143,16 @@ def compute_md5sum(filepath, block_size=8 * 1024 * 1024):
     except Exception as exc:
         log.debug ("compute_md5sum: could not read '%s': %s", filepath, exc)
         return None
+    
+def uri_to_local_path(uri):
+    if uri is None:
+        return None
+    parts = uri.split("://", 1)
+    if len(parts) == 2:
+        return parts[1]   
+
+    return uri
+
 
 
 if __name__ == '__main__':

--- a/genpipes/tools/job2json_project_tracking.py
+++ b/genpipes/tools/job2json_project_tracking.py
@@ -12,6 +12,7 @@ import time
 import random
 import shutil
 import signal
+import hashlib
 
 from datetime import datetime
 
@@ -27,6 +28,7 @@ def main(args=None):
         parser.add_argument('-m', '--metrics', required=False, help="comma-separated list of metrics of the current job: name=value,name=value,... With <name> = metric name; <value> = metric value")
         parser.add_argument('-o','--json_outfile', required=True, help="name of json output file")
         parser.add_argument('-f', '--status', required=False, help="status of job")
+        parser.add_argument('-F', '--file_paths', required=False, help="comma-separated list of output file paths to compute MD5 for (paths as on the executing node)")
         args = parser.parse_args()
 
     sample_list = args.sample_names.split(",")
@@ -79,6 +81,29 @@ def main(args=None):
                                             'metric_name': metric_name,
                                             'metric_value': metric_value
                                             }]
+                                if args.file_paths:
+                                    file_paths = [p for p in args.file_paths.split(",") if p.strip()]
+                                    for fp in file_paths:
+                                        base = os.path.basename(fp)
+                                        md5 = compute_md5sum(fp) if os.path.exists(fp) and os.path.isfile(fp) else None
+                                        try:
+                                            for fobj in job['file']:
+                                                if fobj.get('file_name') == base:
+                                                    fobj['file_md5sum'] = md5
+                                                    break
+                                            else:
+                                                job['file'].append({
+                                                    'location_uri': None,
+                                                    'file_name': base,
+                                                    'file_md5sum': md5
+                                                })
+                                        except KeyError:
+                                            job['file'] = [{
+                                                'location_uri': None,
+                                                'file_name': base,
+                                                'file_md5sum': md5
+                                            }]
+
 
         # Print to file
         with open(args.json_outfile, 'w') as out_json:
@@ -113,6 +138,20 @@ def unlock(filepath):
     Unlocking filepath by removing the .lock file
     """
     shutil.rmtree(filepath + '.lock', ignore_errors=True)
+
+def compute_md5sum(filepath, block_size=8 * 1024 * 1024):
+    """
+    Compute MD5 hex digest of filepath
+    """
+    try:
+        with open(filepath, 'rb') as fh:
+            h = hashlib.md5()
+            for chunk in iter(lambda: fh.read(block_size), b''):
+                h.update(chunk)
+            return h.hexdigest()
+    except Exception as exc:
+        return None
+
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
Adds an md5sum field in the json file called "file_md5sum" which contains the md5sum calculation made on the output files.

**Example:**
"job_status": "COMPLETED",
                            "metric": [
                                {
                                    "metric_name": "duplication_percent",
                                    "metric_value": "0.02328"
                                }
                            ],
                            "job_stop": "2025-11-20 15:08:36",
                            "job_start": "2025-11-20 14:55:14",
                            "file": [
                                {
                                    "file_name": "NA24385_chr19.sorted.dup.cram",
                                    "location_uri": "abacus:///nb/home/.../test/alignment/NA24385_chr19/NA24385_chr19.sorted.dup.cram",
                                    **"file_md5sum": "0aa09bed61e5f337d02c36ef4899640c"**
                                }, 
